### PR TITLE
ENG-10518: Remove references to deprecated fields mongodb_port_alloc_range_low/high

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ the sidecar container into the AWS ECS. See the [sidecar_ecs_resources.tf](./sid
 Define the sidecar container definition configuration. See the [sidecar_container_definition.tf](./sidecar_ecs/sidecar_container_definition.tf) file. This configuration consists of a list of valid task container definition parameters. For a detailed description of what parameters are available, see the [Task Definition Parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) in the
 official AWS Developer Guide.
 
-## Configure the sidecar for MongoDB cluster
-In case you're using a sidecar for a MongoDB cluster, it will be necessary
-to configure the MongoDB port allocation range thats going to be used by
-the sidecar for cluster monitoring. See the `mongodb_port_alloc_range_low` 
-and `mongodb_port_alloc_range_high` variables in the [variables_sidecar.tf](./sidecar_ecs/variables_sidecar.tf) file.
-
 ## Next steps
 In this guide, we described how to deploy and configure a single container sidecar into the AWS ECS. 
 To learn how to access a repository through the sidecar, see the documentation

--- a/sidecar_ecs/sidecar_container_definition.tf
+++ b/sidecar_ecs/sidecar_container_definition.tf
@@ -60,14 +60,6 @@ locals {
           "name"  = "CYRAL_SIDECAR_ENDPOINT"
           "value" = var.sidecar_dns_name
         },
-        {
-          "name"  = "CYRAL_MONGODB_PORT_ALLOC_RANGE_LOW"
-          "value" = tostring(var.mongodb_port_alloc_range_low)
-        },
-        {
-          "name"  = "CYRAL_MONGODB_PORT_ALLOC_RANGE_HIGH"
-          "value" = tostring(var.mongodb_port_alloc_range_high)
-        },
       ]
       # Define the log configuration, where sidecar will ship
       # the container logs to. For more information, see the

--- a/sidecar_ecs/variables_sidecar.tf
+++ b/sidecar_ecs/variables_sidecar.tf
@@ -36,28 +36,6 @@ variable "sidecar_ports" {
   type = list(number)
 }
 
-variable "mongodb_port_alloc_range_low" {
-  description = <<EOF
-Initial value for MongoDB port allocation range. The consecutive ports in the
-range `mongodb_port_alloc_range_low:mongodb_port_alloc_range_high` will be used
-for mongodb cluster monitoring. All the ports in this range must be listed in
-`sidecar_ports`.
-EOF
-  type        = number
-  default = 27017
-}
-
-variable "mongodb_port_alloc_range_high" {
-  description = <<EOF
-Final value for MongoDB port allocation range. The consecutive ports in the
-range `mongodb_port_alloc_range_low:mongodb_port_alloc_range_high` will be used
-for mongodb cluster monitoring. All the ports in this range must be listed in
-`sidecar_ports`.
-EOF
-  type        = number
-  default = 27029
-}
-
 variable "sidecar_dns_name" {
   description = "The fully qualified sidecar domain name. If there's no DNS for the sidecar, use the load balancer DNS instead."
   type = string


### PR DESCRIPTION
# Description

ENG-10518: Remove references to deprecated fields `mongodb_port_alloc_range_low` `mongodb_port_alloc_range_high`

These fields were initially deprecated in sidecar v3.0.0 and will be removed in a future release