### PR TITLE
VPC and Subnet variable updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ suits your needs.
 
     # provide the VPC you want the sidecar to reside in
     vpc_id = "vpc-xxxxxx"
+    subnet_ids = [ "subnet-123", "subnet-456" ]
     ```
 
 1. Run `terraform init`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ suits your needs.
 
 ## Usage
 
-1. From your control plane (https://<tenant>.app.cyral.com) create a new sidecar and select Custom as the deployment type.
+1. From your control plane (https://_tenant_.app.cyral.com) create a new sidecar and select Custom as the deployment type.
 1. Save the infromation for the steps below.
 1. Clone this repository and go to the `sidecar_ecs` directory.
 1. Create a sidecar_values.tfvars file in with the following content:
@@ -37,7 +37,7 @@ suits your needs.
     sidecar_ports = [ 5432 ]
 
     # provide the VPC you want the sidecar to reside in
-    sidecar_vpc_id = "vpc-xxxxxx"
+    vpc_id = "vpc-xxxxxx"
     ```
 
 1. Run `terraform init`

--- a/sidecar_ecs/variables_aws.tf
+++ b/sidecar_ecs/variables_aws.tf
@@ -6,8 +6,6 @@ variable "vpc_id" {
 variable "subnet_ids" {
   type = list(string)
   description = "The list of subnets the ECS service and loadbalancer will use. If no value is provided it will attempt to us all subnets on the VPC"
-  default = null
-
 }
 
 variable "load_balancer_scheme" {

--- a/sidecar_ecs/variables_aws.tf
+++ b/sidecar_ecs/variables_aws.tf
@@ -1,6 +1,13 @@
-variable "sidecar_vpc_id" {
+variable "vpc_id" {
   description = "The VPC ID of the sidecar subnets."
   type        = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+  description = "The list of subnets the ECS service and loadbalancer will use. If no value is provided it will attempt to us all subnets on the VPC"
+  default = null
+
 }
 
 variable "load_balancer_scheme" {


### PR DESCRIPTION
Made some changes to the variables related to VPC/Subnets

- Change `sidecar_vpc_id` to `vpc_id`
- Add `subnet_ids` to require specifying the subnets to use

Testing
- Typical install with providing vpc/subnet ids